### PR TITLE
Update Facebook extractor for graph 2.1

### DIFF
--- a/src/OAuth/UserData/Extractor/Facebook.php
+++ b/src/OAuth/UserData/Extractor/Facebook.php
@@ -22,9 +22,9 @@ class Facebook extends LazyExtractor
 {
 
     /**
-     * Request contants
+     * Request constants
      */
-    const REQUEST_PROFILE = '/me';
+    const REQUEST_PROFILE = '/me?fields=email,name,first_name,last_name'; //new api requires you to ask for the e-mail address
     const REQUEST_IMAGE = '/me/picture?type=large&redirect=false';
 
     /**


### PR DESCRIPTION
Updating facebook extractor to explicitly request email address field, name, first_name & last name. In graph API 2.1 and above you must ask permission for email address and now as /me only returns id and name. 

This will help fix issue https://github.com/concrete5/concrete5/issues/5785 in the core